### PR TITLE
Cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,10 @@
 </head>
 
 <body>
-    <h1>Hi!</h1>
+    <h1>An Introduction to Our Animals</h1>
+    <div id="animalCardContainer">
+
+    </div>
     <script src="./main.js"></script>
 </body>
 

--- a/index.html
+++ b/index.html
@@ -4,19 +4,20 @@
 <head>
     <meta charset="UTF-8" />
     <title>Animal Introduction</title>
+    <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
     <link rel="stylesheet" href="./main.css" />
 </head>
 
 <body>
-    <h1 class='page-title'>An Introduction to Our Animals</h1>
-    <div class="button-container" id="buttonContainer">
-<button id="cat">Cat</button>
-<button id="dog">Dog</button>
-<button id="dino">Dino</button>
-<button id="all">All</button>
+    <h1 class='page-title title padding-vertical'>An Introduction to Our Animals</h1>
+    <div class="button-container padding" id="buttonContainer">
+        <button class="button padding cat" id="cat">Cat</button>
+        <button class="button padding dog" id="dog">Dog</button>
+        <button class="button padding dino" id="dino">Dino</button>
+        <button class="button padding all" id="all">All</button>
 
     </div>
-    <div id="animalCardContainer">
+    <div class="card-container padding" id="animalCardContainer">
 
     </div>
     <script src="./main.js"></script>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,14 @@
 </head>
 
 <body>
-    <h1>An Introduction to Our Animals</h1>
+    <h1 class='page-title'>An Introduction to Our Animals</h1>
+    <div class="button-container" id="buttonContainer">
+<button id="cat">Cat</button>
+<button id="dog">Dog</button>
+<button id="dino">Dino</button>
+<button id="all">All</button>
+
+    </div>
     <div id="animalCardContainer">
 
     </div>

--- a/main.css
+++ b/main.css
@@ -1,3 +1,66 @@
+* {
+    padding: 0;
+    margin: 0;
+    box-sizing: border-box;
+}
+
 body {
+    background-color: #bcada3;
+    color: chocolate;
+    display: flex;
+    flex-flow: column nowrap;
+}
+
+.button-container {
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: space-around;
+}
+
+.button .dino {
+    background-color: #cc5500;
+}
+
+.button .cat {
+    background-color: #007fff;
+}
+
+.button .dog {
+    background-color: #2d572c;
+}
+
+.card-container {
+    display: flex;
+    flex-flow: row wrap;
+}
+
+.card {
+    display: flex;
+    flex-flow: column nowrap;
+    width: 30%;
+}
+
+.title {
+    width: 100%;
+    text-align: center;
+}
+
+.animal-image {
+    width: 100%;
+    height: 300px;
+}
+
+.card .dino {
+    background-color: #edb059;
+    border: 3px solid #cc5500;
+}
+
+.card .cat {
     background-color: lightblue;
+    border: 3px solid #007fff;
+}
+
+.card .dog {
+    background-color: lightgreen;
+    border: 3px solid #2d572c;
 }

--- a/main.js
+++ b/main.js
@@ -1,1 +1,237 @@
-console.log('Hello');
+const pets = [
+       {
+         name: "Dusty",
+         color: "Green",
+         specialSkill: "Gives sincere apologies.",
+         type: "cat",
+         imageUrl: "http://kittentoob.com/wp-content/uploads/2015/06/funny-cat-with-a-towel.jpg(38 kB)collapse"
+       },
+       {
+         name: "Trouble",
+         color: "Poop-Colored",
+         specialSkill: "Just picks the tomatoes off of a sandwich instead of requesting a whole new sandwich.",
+         type: "dino",
+         imageUrl: "http://www.jozilife.co.za/wp-content/uploads/The-Dino-Expo.jpg(160 kB)collapse"
+       },
+    {
+         name: "Whiskers",
+         color: "Yellow",
+         specialSkill: "Can prove he is a real man by drinking whiskey.",
+         type: "dino",
+         imageUrl: "https://mydinosaurs.com/wp-content/uploads/2017/02/2-3-600x400.jpg(68 kB)collapse"
+       },
+       {
+         name: "Coco",
+         color: "Black",
+         specialSkill: "Burps minimally.",
+         type: "dog",
+         imageUrl: "http://cdn.akc.org/content/article-body-image/funny-pembroke_welsh_corgi.jpg(41 kB)collapse"
+       },
+       {
+         name: "Spooky",
+         color: "Brown",
+         specialSkill: "Comfortable in the outdoors for up to eight hours.",
+         type: "cat",
+         imageUrl: "http://www.catster.com/wp-content/uploads/2017/08/A-fluffy-cat-looking-funny-surprised-or-concerned.jpg(170 kB)collapse"
+       },
+       {
+         name: "Tiger",
+         color: "Black",
+         specialSkill: "Can read (but cannot understand) Hebrew.",
+         type: "dog",
+         imageUrl: "https://upload.wikimedia.org/wikipedia/commons/7/7e/Basset_Hound_600.jpg(98 kB)"
+    },
+    {
+             name: "Oreo",
+             color: "Yellow",
+             specialSkill: "Able to stop chewing ice or whistling on request.",
+             type: "cat",
+             imageUrl: "https://i.pinimg.com/originals/9d/da/3e/9dda3e5fd2b9886fc3d13ee47f52e8a0.jpg(27 kB)collapse"
+           },
+           {
+             name: "Ginger",
+             color: "Grey",
+             specialSkill: "Comfortable in the outdoors for up to eight hours.",
+             type: "dino",
+             imageUrl: "http://www.theouthousers.com/images/jck//ThanosCopter/news/grumpasaur.jpg(192 kB)collapse"
+           },
+           {
+             name: "Sassy",
+             color: "Poop-Colored",
+             specialSkill: "Adept at talking self and others out of fights.",
+             type: "cat",
+             imageUrl: "https://tailandfur.com/wp-content/uploads/2015/09/40-Amazing-Cat-Funny-Moment-Pictures-Feature-Image.jpg(63 kB)collapse"
+           },
+           {
+             name: "Sammy",
+             color: "Blue",
+             specialSkill: "Listens attentively to boring stories.",
+             type: "cat",
+             imageUrl: "https://i.pinimg.com/originals/04/54/92/0454926d39eeb420f4f01948e94e9e41.jpg(32 kB)collapse"
+           },
+        {
+             name: "Coco",
+             color: "Orange",
+             specialSkill: "Can be around food without staring creepily at it.",
+             type: "dino",
+             imageUrl: "http://www.cantref.com/userfiles/events/walking%20dino.jpg?w=600"
+           },
+           {
+             name: "Buster",
+             color: "Green",
+             specialSkill: "Does not use excessive acronyms.",
+             type: "dog",
+             imageUrl: "https://i.pinimg.com/originals/1f/30/8c/1f308c9c108a384b91b39430cc7312e9.jpg"
+           },
+           {
+             name: "Chester",
+             color: "Red",
+             specialSkill: "Expertly quotes and recognizes dialogue from early seasons of The Simpsons.",
+             type: "dog",
+             imageUrl: "http://1kjkdg1axrkd2g03cnboj761.wpengine.netdna-cdn.com/wp-content/uploads/2017/12/braydon-anderson-105552-e1512684107659.jpg"
+           },
+           {
+             name: "Samantha",
+             color: "Brown",
+             specialSkill: "Always up for dessert.",
+             type: "cat",
+             imageUrl: "http://3.bp.blogspot.com/-RzIFLsIO-XQ/UFoMLOT66JI/AAAAAAAAVps/JRF98hdA9S8/s640/funny-cat-pictures-016-027.jpg"
+           },
+           {
+             name: "Coco",
+             color: "Red",
+             specialSkill: "Burps minimally.",
+             type: "cat",
+             imageUrl: "http://cathumor.net/wp-content/uploads/2013/12/cat-humor-funny-karate-cat-2.jpg"
+           },
+           {
+             name: "Smokey",
+             color: "Poop-Colored",
+             specialSkill: "Drives at a safe rate of speed in snow or rain.",
+             type: "dino",
+             imageUrl: "https://images.readwrite.com/wp-content/uploads/2018/03/t-rex-dino-quiz-e1490854556549.jpg"
+           },
+        {
+             name: "Muffin",
+             color: "Yellow",
+             specialSkill: "Does not freak out if you haven’t seen his favorite movie (The Big Lebowski).",
+             type: "cat",
+             imageUrl: "http://www.funnycatsite.com/pictures/Close_Up_Yawn.jpg"
+           },
+           {
+             name: "Salem",
+             color: "Poop-Colored",
+             specialSkill: "Proficient in air guitar",
+             type: "dino",
+             imageUrl: "https://www.nation.co.ke/image/view/-/4078922/highRes/1742693/-/maxw/600/-/1453yvh/-/DINO.jpg"
+           },
+           {
+             name: "Callie",
+             color: "Blue",
+             specialSkill: "Listens attentively to boring stories.",
+             type: "dog",
+             imageUrl: "http://dailynewsdig.com/wp-content/uploads/2014/03/Creative-And-Funny-Dog-Stock-Photography-Pictures-2.jpg"
+           },
+           {
+             name: "Spooky",
+             color: "Black",
+             specialSkill: "Uses litter box at appropriate hours.",
+             type: "cat",
+             imageUrl: "http://www.funnycatsite.com/pictures/Lazy_White_Cat.jpg"
+           },
+           {
+             name: "Miss kitty",
+             color: "Red",
+             specialSkill: "Owns a Nintendo Power Glove.",
+             type: "dino",
+             imageUrl: "https://img.buzzfeed.com/buzzfeed-static/static/2015-11/2/12/enhanced/webdr15/anigif_enhanced-29802-1446485228-10.gif?crop=250:165;0,0&downsize=715"
+           },
+           {
+             name: "Snuggles",
+             color: "Orange",
+             specialSkill: "Is comfortable with jokes about his receding hairline.",
+             type: "cat",
+             imageUrl: "http://funnyanimalphoto.com/wp-content/uploads/2013/08/cat_caught_mouse_thegatewaypundit.jpg"
+           },
+        {
+             name: "Buddy",
+             color: "Red",
+             specialSkill: "Enjoys fine wine.",
+             type: "dog",
+             imageUrl: "http://1.bp.blogspot.com/-VjM0CmtN-vU/T7YX-LXa09I/AAAAAAAADA0/Vt1oGWEG0lw/s1600/sheepdog+border+collie+shakes+off+water+funny+picture+photo+pulling+faces+raspberry+tongue.jpg(150 kB)collapse"
+           },
+           {
+             name: "George",
+             color: "Brown",
+             specialSkill: "Participates in karaoke but does not force others to go out to karaoke.",
+             type: "dog",
+             imageUrl: "http://www.dogbreedplus.com/dog_breeds/images/basset-hound-4.jpg(58 kB)collapse"
+           },
+           {
+             name: "Salem",
+             color: "Red",
+             specialSkill: "Knows the words to 4 rap songs.",
+             type: "cat",
+             imageUrl: "http://funbk.s3.amazonaws.com/wp-content/uploads/2016/06/funny-cat-video-which-will-make-you-laugh-louder.jpg(23 kB)collapse"
+           },
+           {
+             name: "Bubba",
+             color: "Yellow",
+             specialSkill: "Cleans himself.",
+             type: "dog",
+             imageUrl: "https://www.thetrendywhippet.co.uk/wp-content/uploads/2016/11/IMG_1651-600x400.jpg(25 kB)collapse"
+           },
+           {
+             name: "Chloe",
+             color: "Green",
+             specialSkill: "Admits he is wrong",
+             type: "dino",
+             imageUrl: "https://assets.creationmuseum.org/img/pages/1703-DinoDen-TwoCard.jpg(50 kB)collapse"
+           },
+        {
+             name: "Nala",
+             color: "Purple",
+             specialSkill: "Dances when he has to.",
+             type: "cat",
+             imageUrl: "https://tailandfur.com/wp-content/uploads/2016/03/40-Scary-and-Funny-Cat-Pictures-8.jpg(90 kB)collapse"
+           },
+           {
+             name: "Oscar",
+             color: "Green",
+             specialSkill: "Gives hugs with appropriate pressure and for the right length of time.",
+             type: "cat",
+             imageUrl: "http://img.izismile.com/img/img2/20090219/cats_02.jpg(48 kB)collapse"
+           },
+           {
+             name: "Lucy",
+             color: "Red",
+             specialSkill: "Doesn’t get weirded out by the word “moist.”",
+             type: "dino",
+             imageUrl: "http://lsae2.iypcdn.com/static//modules/uploads/photos/language1/dino-live-22.jpg?119(138 kB)collapse"
+           }
+    ];
+        const printToDom = (divId, textToPrint) => {
+const selectedDiv = document.getElementById(divId);
+selectedDiv.innerHTML = textToPrint;
+        };
+        const buildDomString = (animalArray) => {
+let domString = '';
+animalArray.forEach((animal) => {
+domString += `<div class='card'>`;
+domString += `<h3>${animal.name} The ${animal.type}</h3>`;
+domString += `<img class='animal-image' src='${animal.imageUrl}' alt='Image of ${animal.name}, the ${animal.color} ${animal.type}'/>`;
+domString += `<p>${animal.name} is a/an ${animal.color} ${animal.type}</p>`;
+domString += `<p>Their special skill is:</p>`;
+domString += `<ul class='unordered-list'>`;
+domString += `<li>${animal.specialSkill}</li>`;
+domString += `</ul>`;
+domString += `</div>`;
+});
+printToDom('animalCardContainer', domString);
+        };
+
+        
+        const init = () => {
+buildDomString(pets);
+        };
+        init();

--- a/main.js
+++ b/main.js
@@ -1,219 +1,222 @@
 const pets = [
-       {
-         name: "Dusty",
-         color: "Green",
-         specialSkill: "Gives sincere apologies.",
-         type: "cat",
-         imageUrl: "http://kittentoob.com/wp-content/uploads/2015/06/funny-cat-with-a-towel.jpg(38 kB)collapse"
-       },
-       {
-         name: "Trouble",
-         color: "Poop-Colored",
-         specialSkill: "Just picks the tomatoes off of a sandwich instead of requesting a whole new sandwich.",
-         type: "dino",
-         imageUrl: "http://www.jozilife.co.za/wp-content/uploads/The-Dino-Expo.jpg(160 kB)collapse"
-       },
     {
-         name: "Whiskers",
-         color: "Yellow",
-         specialSkill: "Can prove he is a real man by drinking whiskey.",
-         type: "dino",
-         imageUrl: "https://mydinosaurs.com/wp-content/uploads/2017/02/2-3-600x400.jpg(68 kB)collapse"
-       },
-       {
-         name: "Coco",
-         color: "Black",
-         specialSkill: "Burps minimally.",
-         type: "dog",
-         imageUrl: "http://cdn.akc.org/content/article-body-image/funny-pembroke_welsh_corgi.jpg(41 kB)collapse"
-       },
-       {
-         name: "Spooky",
-         color: "Brown",
-         specialSkill: "Comfortable in the outdoors for up to eight hours.",
-         type: "cat",
-         imageUrl: "http://www.catster.com/wp-content/uploads/2017/08/A-fluffy-cat-looking-funny-surprised-or-concerned.jpg(170 kB)collapse"
-       },
-       {
-         name: "Tiger",
-         color: "Black",
-         specialSkill: "Can read (but cannot understand) Hebrew.",
-         type: "dog",
-         imageUrl: "https://upload.wikimedia.org/wikipedia/commons/7/7e/Basset_Hound_600.jpg(98 kB)"
+      name: "Dusty",
+      color: "Green",
+      specialSkill: "Gives sincere apologies.",
+      type: "cat",
+      imageUrl: "http://kittentoob.com/wp-content/uploads/2015/06/funny-cat-with-a-towel.jpg"
     },
     {
-             name: "Oreo",
-             color: "Yellow",
-             specialSkill: "Able to stop chewing ice or whistling on request.",
-             type: "cat",
-             imageUrl: "https://i.pinimg.com/originals/9d/da/3e/9dda3e5fd2b9886fc3d13ee47f52e8a0.jpg(27 kB)collapse"
-           },
-           {
-             name: "Ginger",
-             color: "Grey",
-             specialSkill: "Comfortable in the outdoors for up to eight hours.",
-             type: "dino",
-             imageUrl: "http://www.theouthousers.com/images/jck//ThanosCopter/news/grumpasaur.jpg(192 kB)collapse"
-           },
-           {
-             name: "Sassy",
-             color: "Poop-Colored",
-             specialSkill: "Adept at talking self and others out of fights.",
-             type: "cat",
-             imageUrl: "https://tailandfur.com/wp-content/uploads/2015/09/40-Amazing-Cat-Funny-Moment-Pictures-Feature-Image.jpg(63 kB)collapse"
-           },
-           {
-             name: "Sammy",
-             color: "Blue",
-             specialSkill: "Listens attentively to boring stories.",
-             type: "cat",
-             imageUrl: "https://i.pinimg.com/originals/04/54/92/0454926d39eeb420f4f01948e94e9e41.jpg(32 kB)collapse"
-           },
-        {
-             name: "Coco",
-             color: "Orange",
-             specialSkill: "Can be around food without staring creepily at it.",
-             type: "dino",
-             imageUrl: "http://www.cantref.com/userfiles/events/walking%20dino.jpg?w=600"
-           },
-           {
-             name: "Buster",
-             color: "Green",
-             specialSkill: "Does not use excessive acronyms.",
-             type: "dog",
-             imageUrl: "https://i.pinimg.com/originals/1f/30/8c/1f308c9c108a384b91b39430cc7312e9.jpg"
-           },
-           {
-             name: "Chester",
-             color: "Red",
-             specialSkill: "Expertly quotes and recognizes dialogue from early seasons of The Simpsons.",
-             type: "dog",
-             imageUrl: "http://1kjkdg1axrkd2g03cnboj761.wpengine.netdna-cdn.com/wp-content/uploads/2017/12/braydon-anderson-105552-e1512684107659.jpg"
-           },
-           {
-             name: "Samantha",
-             color: "Brown",
-             specialSkill: "Always up for dessert.",
-             type: "cat",
-             imageUrl: "http://3.bp.blogspot.com/-RzIFLsIO-XQ/UFoMLOT66JI/AAAAAAAAVps/JRF98hdA9S8/s640/funny-cat-pictures-016-027.jpg"
-           },
-           {
-             name: "Coco",
-             color: "Red",
-             specialSkill: "Burps minimally.",
-             type: "cat",
-             imageUrl: "http://cathumor.net/wp-content/uploads/2013/12/cat-humor-funny-karate-cat-2.jpg"
-           },
-           {
-             name: "Smokey",
-             color: "Poop-Colored",
-             specialSkill: "Drives at a safe rate of speed in snow or rain.",
-             type: "dino",
-             imageUrl: "https://images.readwrite.com/wp-content/uploads/2018/03/t-rex-dino-quiz-e1490854556549.jpg"
-           },
-        {
-             name: "Muffin",
-             color: "Yellow",
-             specialSkill: "Does not freak out if you haven’t seen his favorite movie (The Big Lebowski).",
-             type: "cat",
-             imageUrl: "http://www.funnycatsite.com/pictures/Close_Up_Yawn.jpg"
-           },
-           {
-             name: "Salem",
-             color: "Poop-Colored",
-             specialSkill: "Proficient in air guitar",
-             type: "dino",
-             imageUrl: "https://www.nation.co.ke/image/view/-/4078922/highRes/1742693/-/maxw/600/-/1453yvh/-/DINO.jpg"
-           },
-           {
-             name: "Callie",
-             color: "Blue",
-             specialSkill: "Listens attentively to boring stories.",
-             type: "dog",
-             imageUrl: "http://dailynewsdig.com/wp-content/uploads/2014/03/Creative-And-Funny-Dog-Stock-Photography-Pictures-2.jpg"
-           },
-           {
-             name: "Spooky",
-             color: "Black",
-             specialSkill: "Uses litter box at appropriate hours.",
-             type: "cat",
-             imageUrl: "http://www.funnycatsite.com/pictures/Lazy_White_Cat.jpg"
-           },
-           {
-             name: "Miss kitty",
-             color: "Red",
-             specialSkill: "Owns a Nintendo Power Glove.",
-             type: "dino",
-             imageUrl: "https://img.buzzfeed.com/buzzfeed-static/static/2015-11/2/12/enhanced/webdr15/anigif_enhanced-29802-1446485228-10.gif?crop=250:165;0,0&downsize=715"
-           },
-           {
-             name: "Snuggles",
-             color: "Orange",
-             specialSkill: "Is comfortable with jokes about his receding hairline.",
-             type: "cat",
-             imageUrl: "http://funnyanimalphoto.com/wp-content/uploads/2013/08/cat_caught_mouse_thegatewaypundit.jpg"
-           },
-        {
-             name: "Buddy",
-             color: "Red",
-             specialSkill: "Enjoys fine wine.",
-             type: "dog",
-             imageUrl: "http://1.bp.blogspot.com/-VjM0CmtN-vU/T7YX-LXa09I/AAAAAAAADA0/Vt1oGWEG0lw/s1600/sheepdog+border+collie+shakes+off+water+funny+picture+photo+pulling+faces+raspberry+tongue.jpg(150 kB)collapse"
-           },
-           {
-             name: "George",
-             color: "Brown",
-             specialSkill: "Participates in karaoke but does not force others to go out to karaoke.",
-             type: "dog",
-             imageUrl: "http://www.dogbreedplus.com/dog_breeds/images/basset-hound-4.jpg(58 kB)collapse"
-           },
-           {
-             name: "Salem",
-             color: "Red",
-             specialSkill: "Knows the words to 4 rap songs.",
-             type: "cat",
-             imageUrl: "http://funbk.s3.amazonaws.com/wp-content/uploads/2016/06/funny-cat-video-which-will-make-you-laugh-louder.jpg(23 kB)collapse"
-           },
-           {
-             name: "Bubba",
-             color: "Yellow",
-             specialSkill: "Cleans himself.",
-             type: "dog",
-             imageUrl: "https://www.thetrendywhippet.co.uk/wp-content/uploads/2016/11/IMG_1651-600x400.jpg(25 kB)collapse"
-           },
-           {
-             name: "Chloe",
-             color: "Green",
-             specialSkill: "Admits he is wrong",
-             type: "dino",
-             imageUrl: "https://assets.creationmuseum.org/img/pages/1703-DinoDen-TwoCard.jpg(50 kB)collapse"
-           },
-        {
-             name: "Nala",
-             color: "Purple",
-             specialSkill: "Dances when he has to.",
-             type: "cat",
-             imageUrl: "https://tailandfur.com/wp-content/uploads/2016/03/40-Scary-and-Funny-Cat-Pictures-8.jpg(90 kB)collapse"
-           },
-           {
-             name: "Oscar",
-             color: "Green",
-             specialSkill: "Gives hugs with appropriate pressure and for the right length of time.",
-             type: "cat",
-             imageUrl: "http://img.izismile.com/img/img2/20090219/cats_02.jpg(48 kB)collapse"
-           },
-           {
-             name: "Lucy",
-             color: "Red",
-             specialSkill: "Doesn’t get weirded out by the word “moist.”",
-             type: "dino",
-             imageUrl: "http://lsae2.iypcdn.com/static//modules/uploads/photos/language1/dino-live-22.jpg?119(138 kB)collapse"
-           }
-    ];
+      name: "Trouble",
+      color: "Poop-Colored",
+      specialSkill: "Just picks the tomatoes off of a sandwich instead of requesting a whole new sandwich.",
+      type: "dino",
+      imageUrl: "http://www.jozilife.co.za/wp-content/uploads/The-Dino-Expo.jpg"
+    },
+    {
+      name: "Whiskers",
+      color: "Yellow",
+      specialSkill: "Can prove he is a real man by drinking whiskey.",
+      type: "dino",
+      imageUrl: "https://mydinosaurs.com/wp-content/uploads/2017/02/2-3-600x400.jpg"
+    },
+    {
+      name: "Coco",
+      color: "Black",
+      specialSkill: "Burps minimally.",
+      type: "dog",
+      imageUrl: "http://cdn.akc.org/content/article-body-image/funny-pembroke_welsh_corgi.jpg"
+    },
+    {
+      name: "Spooky",
+      color: "Brown",
+      specialSkill: "Comfortable in the outdoors for up to eight hours.",
+      type: "cat",
+      imageUrl: "http://www.catster.com/wp-content/uploads/2017/08/A-fluffy-cat-looking-funny-surprised-or-concerned.jpg"
+    },
+    {
+      name: "Tiger",
+      color: "Black",
+      specialSkill: "Can read (but cannot understand) Hebrew.",
+      type: "dog",
+      imageUrl: "https://upload.wikimedia.org/wikipedia/commons/7/7e/Basset_Hound_600.jpg"
+    },
+    {
+      name: "Oreo",
+      color: "Yellow",
+      specialSkill: "Able to stop chewing ice or whistling on request.",
+      type: "cat",
+      imageUrl: "https://i.pinimg.com/originals/9d/da/3e/9dda3e5fd2b9886fc3d13ee47f52e8a0.jpg"
+    },
+    {
+      name: "Ginger",
+      color: "Grey",
+      specialSkill: "Comfortable in the outdoors for up to eight hours.",
+      type: "dino",
+      imageUrl: "http://www.theouthousers.com/images/jck//ThanosCopter/news/grumpasaur.jpg"
+    },
+    {
+      name: "Sassy",
+      color: "Poop-Colored",
+      specialSkill: "Adept at talking self and others out of fights.",
+      type: "cat",
+      imageUrl: "https://tailandfur.com/wp-content/uploads/2015/09/40-Amazing-Cat-Funny-Moment-Pictures-Feature-Image.jpg"
+    },
+    {
+      name: "Sammy",
+      color: "Blue",
+      specialSkill: "Listens attentively to boring stories.",
+      type: "cat",
+      imageUrl: "https://i.pinimg.com/originals/04/54/92/0454926d39eeb420f4f01948e94e9e41.jpg"
+    },
+    {
+      name: "Coco",
+      color: "Orange",
+      specialSkill: "Can be around food without staring creepily at it.",
+      type: "dino",
+      imageUrl: "http://www.cantref.com/userfiles/events/walking%20dino.jpg?w=600"
+    },
+    {
+      name: "Buster",
+      color: "Green",
+      specialSkill: "Does not use excessive acronyms.",
+      type: "dog",
+      imageUrl: "https://i.pinimg.com/originals/1f/30/8c/1f308c9c108a384b91b39430cc7312e9.jpg"
+    },
+    {
+      name: "Chester",
+      color: "Red",
+      specialSkill: "Expertly quotes and recognizes dialogue from early seasons of The Simpsons.",
+      type: "dog",
+      imageUrl: "http://1kjkdg1axrkd2g03cnboj761.wpengine.netdna-cdn.com/wp-content/uploads/2017/12/braydon-anderson-105552-e1512684107659.jpg"
+    },
+    {
+      name: "Samantha",
+      color: "Brown",
+      specialSkill: "Always up for dessert.",
+      type: "cat",
+      imageUrl: "http://3.bp.blogspot.com/-RzIFLsIO-XQ/UFoMLOT66JI/AAAAAAAAVps/JRF98hdA9S8/s640/funny-cat-pictures-016-027.jpg"
+    },
+    {
+      name: "Coco",
+      color: "Red",
+      specialSkill: "Burps minimally.",
+      type: "cat",
+      imageUrl: "http://cathumor.net/wp-content/uploads/2013/12/cat-humor-funny-karate-cat-2.jpg"
+    },
+    {
+      name: "Smokey",
+      color: "Poop-Colored",
+      specialSkill: "Drives at a safe rate of speed in snow or rain.",
+      type: "dino",
+      imageUrl: "https://images.readwrite.com/wp-content/uploads/2018/03/t-rex-dino-quiz-e1490854556549.jpg"
+    },
+    {
+      name: "Muffin",
+      color: "Yellow",
+      specialSkill: "Does not freak out if you haven’t seen his favorite movie (The Big Lebowski).",
+      type: "cat",
+      imageUrl: "http://www.funnycatsite.com/pictures/Close_Up_Yawn.jpg"
+    },
+    {
+      name: "Salem",
+      color: "Poop-Colored",
+      specialSkill: "Proficient in air guitar",
+      type: "dino",
+      imageUrl: "https://www.nation.co.ke/image/view/-/4078922/highRes/1742693/-/maxw/600/-/1453yvh/-/DINO.jpg"
+    },
+    {
+      name: "Callie",
+      color: "Blue",
+      specialSkill: "Listens attentively to boring stories.",
+      type: "dog",
+      imageUrl: "http://cdn.akc.org/content/article-body-image/funny-pembroke_welsh_corgi.jpg"
+    },
+    {
+      name: "Spooky",
+      color: "Black",
+      specialSkill: "Uses litter box at appropriate hours.",
+      type: "cat",
+      imageUrl: "http://www.funnycatsite.com/pictures/Lazy_White_Cat.jpg"
+    },
+    {
+      name: "Miss kitty",
+      color: "Red",
+      specialSkill: "Owns a Nintendo Power Glove.",
+      type: "dino",
+      imageUrl: "https://img.buzzfeed.com/buzzfeed-static/static/2015-11/2/12/enhanced/webdr15/anigif_enhanced-29802-1446485228-10.gif?crop=250:165;0,0&downsize=715"
+    },
+    {
+      name: "Snuggles",
+      color: "Orange",
+      specialSkill: "Is comfortable with jokes about his receding hairline.",
+      type: "cat",
+      imageUrl: "http://funnyanimalphoto.com/wp-content/uploads/2013/08/cat_caught_mouse_thegatewaypundit.jpg"
+    },
+    {
+      name: "Buddy",
+      color: "Red",
+      specialSkill: "Enjoys fine wine.",
+      type: "dog",
+      imageUrl: "http://1.bp.blogspot.com/-VjM0CmtN-vU/T7YX-LXa09I/AAAAAAAADA0/Vt1oGWEG0lw/s1600/sheepdog+border+collie+shakes+off+water+funny+picture+photo+pulling+faces+raspberry+tongue.jpg"
+    },
+    {
+      name: "George",
+      color: "Brown",
+      specialSkill: "Participates in karaoke but does not force others to go out to karaoke.",
+      type: "dog",
+      imageUrl: "http://www.dogbreedplus.com/dog_breeds/images/basset-hound-4.jpg"
+    },
+    {
+      name: "Salem",
+      color: "Red",
+      specialSkill: "Knows the words to 4 rap songs.",
+      type: "cat",
+      imageUrl: "http://funbk.s3.amazonaws.com/wp-content/uploads/2016/06/funny-cat-video-which-will-make-you-laugh-louder.jpg"
+    },
+    {
+      name: "Bubba",
+      color: "Yellow",
+      specialSkill: "Cleans himself.",
+      type: "dog",
+      imageUrl: "https://www.thetrendywhippet.co.uk/wp-content/uploads/2016/11/IMG_1651-600x400.jpg"
+    },
+    {
+      name: "Chloe",
+      color: "Green",
+      specialSkill: "Admits he is wrong",
+      type: "dino",
+      imageUrl: "https://assets.creationmuseum.org/img/pages/1703-DinoDen-TwoCard.jpg"
+    },
+    {
+      name: "Nala",
+      color: "Purple",
+      specialSkill: "Dances when he has to.",
+      type: "cat",
+      imageUrl: "https://tailandfur.com/wp-content/uploads/2016/03/40-Scary-and-Funny-Cat-Pictures-8.jpg"
+    },
+    {
+      name: "Oscar",
+      color: "Green",
+      specialSkill: "Gives hugs with appropriate pressure and for the right length of time.",
+      type: "cat",
+      imageUrl: "http://kittentoob.com/wp-content/uploads/2015/06/funny-cat-with-a-towel.jpg"
+    },
+    {
+      name: "Lucy",
+      color: "Red",
+      specialSkill: "Doesn’t get weirded out by the word “moist.”",
+      type: "dino",
+      imageUrl: "http://lsae2.iypcdn.com/static//modules/uploads/photos/language1/dino-live-22.jpg?119"
+    }
+  ];
+
+
         const printToDom = (divId, textToPrint) => {
 const selectedDiv = document.getElementById(divId);
 selectedDiv.innerHTML = textToPrint;
         };
+
         const buildDomString = (animalArray) => {
 let domString = '';
 animalArray.forEach((animal) => {
@@ -230,8 +233,20 @@ domString += `</div>`;
 printToDom('animalCardContainer', domString);
         };
 
+const buttonClick = (event) => {
+const buttonId = event.target.id;
+console.log(event.target.id);
+};
+
+const eventHandler = () => {
+document.getElementById('cat').addEventListener('click', buttonClick);
+document.getElementById('dog').addEventListener('click', buttonClick);
+document.getElementById('dino').addEventListener('click', buttonClick);
+document.getElementById('all').addEventListener('click', buttonClick);
+};
         
         const init = () => {
 buildDomString(pets);
+eventHandler();
         };
         init();

--- a/main.js
+++ b/main.js
@@ -1,252 +1,275 @@
-const pets = [
-    {
-      name: "Dusty",
-      color: "Green",
-      specialSkill: "Gives sincere apologies.",
-      type: "cat",
-      imageUrl: "http://kittentoob.com/wp-content/uploads/2015/06/funny-cat-with-a-towel.jpg"
-    },
-    {
-      name: "Trouble",
-      color: "Poop-Colored",
-      specialSkill: "Just picks the tomatoes off of a sandwich instead of requesting a whole new sandwich.",
-      type: "dino",
-      imageUrl: "http://www.jozilife.co.za/wp-content/uploads/The-Dino-Expo.jpg"
-    },
-    {
-      name: "Whiskers",
-      color: "Yellow",
-      specialSkill: "Can prove he is a real man by drinking whiskey.",
-      type: "dino",
-      imageUrl: "https://mydinosaurs.com/wp-content/uploads/2017/02/2-3-600x400.jpg"
-    },
-    {
-      name: "Coco",
-      color: "Black",
-      specialSkill: "Burps minimally.",
-      type: "dog",
-      imageUrl: "http://cdn.akc.org/content/article-body-image/funny-pembroke_welsh_corgi.jpg"
-    },
-    {
-      name: "Spooky",
-      color: "Brown",
-      specialSkill: "Comfortable in the outdoors for up to eight hours.",
-      type: "cat",
-      imageUrl: "http://www.catster.com/wp-content/uploads/2017/08/A-fluffy-cat-looking-funny-surprised-or-concerned.jpg"
-    },
-    {
-      name: "Tiger",
-      color: "Black",
-      specialSkill: "Can read (but cannot understand) Hebrew.",
-      type: "dog",
-      imageUrl: "https://upload.wikimedia.org/wikipedia/commons/7/7e/Basset_Hound_600.jpg"
-    },
-    {
-      name: "Oreo",
-      color: "Yellow",
-      specialSkill: "Able to stop chewing ice or whistling on request.",
-      type: "cat",
-      imageUrl: "https://i.pinimg.com/originals/9d/da/3e/9dda3e5fd2b9886fc3d13ee47f52e8a0.jpg"
-    },
-    {
-      name: "Ginger",
-      color: "Grey",
-      specialSkill: "Comfortable in the outdoors for up to eight hours.",
-      type: "dino",
-      imageUrl: "http://www.theouthousers.com/images/jck//ThanosCopter/news/grumpasaur.jpg"
-    },
-    {
-      name: "Sassy",
-      color: "Poop-Colored",
-      specialSkill: "Adept at talking self and others out of fights.",
-      type: "cat",
-      imageUrl: "https://tailandfur.com/wp-content/uploads/2015/09/40-Amazing-Cat-Funny-Moment-Pictures-Feature-Image.jpg"
-    },
-    {
-      name: "Sammy",
-      color: "Blue",
-      specialSkill: "Listens attentively to boring stories.",
-      type: "cat",
-      imageUrl: "https://i.pinimg.com/originals/04/54/92/0454926d39eeb420f4f01948e94e9e41.jpg"
-    },
-    {
-      name: "Coco",
-      color: "Orange",
-      specialSkill: "Can be around food without staring creepily at it.",
-      type: "dino",
-      imageUrl: "http://www.cantref.com/userfiles/events/walking%20dino.jpg?w=600"
-    },
-    {
-      name: "Buster",
-      color: "Green",
-      specialSkill: "Does not use excessive acronyms.",
-      type: "dog",
-      imageUrl: "https://i.pinimg.com/originals/1f/30/8c/1f308c9c108a384b91b39430cc7312e9.jpg"
-    },
-    {
-      name: "Chester",
-      color: "Red",
-      specialSkill: "Expertly quotes and recognizes dialogue from early seasons of The Simpsons.",
-      type: "dog",
-      imageUrl: "http://1kjkdg1axrkd2g03cnboj761.wpengine.netdna-cdn.com/wp-content/uploads/2017/12/braydon-anderson-105552-e1512684107659.jpg"
-    },
-    {
-      name: "Samantha",
-      color: "Brown",
-      specialSkill: "Always up for dessert.",
-      type: "cat",
-      imageUrl: "http://3.bp.blogspot.com/-RzIFLsIO-XQ/UFoMLOT66JI/AAAAAAAAVps/JRF98hdA9S8/s640/funny-cat-pictures-016-027.jpg"
-    },
-    {
-      name: "Coco",
-      color: "Red",
-      specialSkill: "Burps minimally.",
-      type: "cat",
-      imageUrl: "http://cathumor.net/wp-content/uploads/2013/12/cat-humor-funny-karate-cat-2.jpg"
-    },
-    {
-      name: "Smokey",
-      color: "Poop-Colored",
-      specialSkill: "Drives at a safe rate of speed in snow or rain.",
-      type: "dino",
-      imageUrl: "https://images.readwrite.com/wp-content/uploads/2018/03/t-rex-dino-quiz-e1490854556549.jpg"
-    },
-    {
-      name: "Muffin",
-      color: "Yellow",
-      specialSkill: "Does not freak out if you haven’t seen his favorite movie (The Big Lebowski).",
-      type: "cat",
-      imageUrl: "http://www.funnycatsite.com/pictures/Close_Up_Yawn.jpg"
-    },
-    {
-      name: "Salem",
-      color: "Poop-Colored",
-      specialSkill: "Proficient in air guitar",
-      type: "dino",
-      imageUrl: "https://www.nation.co.ke/image/view/-/4078922/highRes/1742693/-/maxw/600/-/1453yvh/-/DINO.jpg"
-    },
-    {
-      name: "Callie",
-      color: "Blue",
-      specialSkill: "Listens attentively to boring stories.",
-      type: "dog",
-      imageUrl: "http://cdn.akc.org/content/article-body-image/funny-pembroke_welsh_corgi.jpg"
-    },
-    {
-      name: "Spooky",
-      color: "Black",
-      specialSkill: "Uses litter box at appropriate hours.",
-      type: "cat",
-      imageUrl: "http://www.funnycatsite.com/pictures/Lazy_White_Cat.jpg"
-    },
-    {
-      name: "Miss kitty",
-      color: "Red",
-      specialSkill: "Owns a Nintendo Power Glove.",
-      type: "dino",
-      imageUrl: "https://img.buzzfeed.com/buzzfeed-static/static/2015-11/2/12/enhanced/webdr15/anigif_enhanced-29802-1446485228-10.gif?crop=250:165;0,0&downsize=715"
-    },
-    {
-      name: "Snuggles",
-      color: "Orange",
-      specialSkill: "Is comfortable with jokes about his receding hairline.",
-      type: "cat",
-      imageUrl: "http://funnyanimalphoto.com/wp-content/uploads/2013/08/cat_caught_mouse_thegatewaypundit.jpg"
-    },
-    {
-      name: "Buddy",
-      color: "Red",
-      specialSkill: "Enjoys fine wine.",
-      type: "dog",
-      imageUrl: "http://1.bp.blogspot.com/-VjM0CmtN-vU/T7YX-LXa09I/AAAAAAAADA0/Vt1oGWEG0lw/s1600/sheepdog+border+collie+shakes+off+water+funny+picture+photo+pulling+faces+raspberry+tongue.jpg"
-    },
-    {
-      name: "George",
-      color: "Brown",
-      specialSkill: "Participates in karaoke but does not force others to go out to karaoke.",
-      type: "dog",
-      imageUrl: "http://www.dogbreedplus.com/dog_breeds/images/basset-hound-4.jpg"
-    },
-    {
-      name: "Salem",
-      color: "Red",
-      specialSkill: "Knows the words to 4 rap songs.",
-      type: "cat",
-      imageUrl: "http://funbk.s3.amazonaws.com/wp-content/uploads/2016/06/funny-cat-video-which-will-make-you-laugh-louder.jpg"
-    },
-    {
-      name: "Bubba",
-      color: "Yellow",
-      specialSkill: "Cleans himself.",
-      type: "dog",
-      imageUrl: "https://www.thetrendywhippet.co.uk/wp-content/uploads/2016/11/IMG_1651-600x400.jpg"
-    },
-    {
-      name: "Chloe",
-      color: "Green",
-      specialSkill: "Admits he is wrong",
-      type: "dino",
-      imageUrl: "https://assets.creationmuseum.org/img/pages/1703-DinoDen-TwoCard.jpg"
-    },
-    {
-      name: "Nala",
-      color: "Purple",
-      specialSkill: "Dances when he has to.",
-      type: "cat",
-      imageUrl: "https://tailandfur.com/wp-content/uploads/2016/03/40-Scary-and-Funny-Cat-Pictures-8.jpg"
-    },
-    {
-      name: "Oscar",
-      color: "Green",
-      specialSkill: "Gives hugs with appropriate pressure and for the right length of time.",
-      type: "cat",
-      imageUrl: "http://kittentoob.com/wp-content/uploads/2015/06/funny-cat-with-a-towel.jpg"
-    },
-    {
-      name: "Lucy",
-      color: "Red",
-      specialSkill: "Doesn’t get weirded out by the word “moist.”",
-      type: "dino",
-      imageUrl: "http://lsae2.iypcdn.com/static//modules/uploads/photos/language1/dino-live-22.jpg?119"
-    }
-  ];
+/*This project is a replication of an in class exercise. 
+I reconstructed, from memory and with a little help from fellow students:
+ A print to DOM function, which prints a string of HTML to a selected element on the page, 
+ A string-builder function, which loops through the provided array and builds cards featuring various animals and executes the print function to print the cards to the page,
+And a  button click function which works with an event handler function to print only selected types of animals' cards to the page based on which button is pressed.*/
 
+//Pets array lists information about various animals
+const pets = [{
+    name: "Dusty",
+    color: "Green",
+    specialSkill: "Gives sincere apologies.",
+    type: "cat",
+    imageUrl: "http://kittentoob.com/wp-content/uploads/2015/06/funny-cat-with-a-towel.jpg"
+  },
+  {
+    name: "Trouble",
+    color: "Poop-Colored",
+    specialSkill: "Just picks the tomatoes off of a sandwich instead of requesting a whole new sandwich.",
+    type: "dino",
+    imageUrl: "http://www.jozilife.co.za/wp-content/uploads/The-Dino-Expo.jpg"
+  },
+  {
+    name: "Whiskers",
+    color: "Yellow",
+    specialSkill: "Can prove he is a real man by drinking whiskey.",
+    type: "dino",
+    imageUrl: "https://mydinosaurs.com/wp-content/uploads/2017/02/2-3-600x400.jpg"
+  },
+  {
+    name: "Coco",
+    color: "Black",
+    specialSkill: "Burps minimally.",
+    type: "dog",
+    imageUrl: "http://cdn.akc.org/content/article-body-image/funny-pembroke_welsh_corgi.jpg"
+  },
+  {
+    name: "Spooky",
+    color: "Brown",
+    specialSkill: "Comfortable in the outdoors for up to eight hours.",
+    type: "cat",
+    imageUrl: "http://www.catster.com/wp-content/uploads/2017/08/A-fluffy-cat-looking-funny-surprised-or-concerned.jpg"
+  },
+  {
+    name: "Tiger",
+    color: "Black",
+    specialSkill: "Can read (but cannot understand) Hebrew.",
+    type: "dog",
+    imageUrl: "https://upload.wikimedia.org/wikipedia/commons/7/7e/Basset_Hound_600.jpg"
+  },
+  {
+    name: "Oreo",
+    color: "Yellow",
+    specialSkill: "Able to stop chewing ice or whistling on request.",
+    type: "cat",
+    imageUrl: "https://i.pinimg.com/originals/9d/da/3e/9dda3e5fd2b9886fc3d13ee47f52e8a0.jpg"
+  },
+  {
+    name: "Ginger",
+    color: "Grey",
+    specialSkill: "Comfortable in the outdoors for up to eight hours.",
+    type: "dino",
+    imageUrl: "http://www.theouthousers.com/images/jck//ThanosCopter/news/grumpasaur.jpg"
+  },
+  {
+    name: "Sassy",
+    color: "Poop-Colored",
+    specialSkill: "Adept at talking self and others out of fights.",
+    type: "cat",
+    imageUrl: "https://tailandfur.com/wp-content/uploads/2015/09/40-Amazing-Cat-Funny-Moment-Pictures-Feature-Image.jpg"
+  },
+  {
+    name: "Sammy",
+    color: "Blue",
+    specialSkill: "Listens attentively to boring stories.",
+    type: "cat",
+    imageUrl: "https://i.pinimg.com/originals/04/54/92/0454926d39eeb420f4f01948e94e9e41.jpg"
+  },
+  {
+    name: "Coco",
+    color: "Orange",
+    specialSkill: "Can be around food without staring creepily at it.",
+    type: "dino",
+    imageUrl: "http://www.cantref.com/userfiles/events/walking%20dino.jpg?w=600"
+  },
+  {
+    name: "Buster",
+    color: "Green",
+    specialSkill: "Does not use excessive acronyms.",
+    type: "dog",
+    imageUrl: "https://i.pinimg.com/originals/1f/30/8c/1f308c9c108a384b91b39430cc7312e9.jpg"
+  },
+  {
+    name: "Chester",
+    color: "Red",
+    specialSkill: "Expertly quotes and recognizes dialogue from early seasons of The Simpsons.",
+    type: "dog",
+    imageUrl: "http://1kjkdg1axrkd2g03cnboj761.wpengine.netdna-cdn.com/wp-content/uploads/2017/12/braydon-anderson-105552-e1512684107659.jpg"
+  },
+  {
+    name: "Samantha",
+    color: "Brown",
+    specialSkill: "Always up for dessert.",
+    type: "cat",
+    imageUrl: "http://3.bp.blogspot.com/-RzIFLsIO-XQ/UFoMLOT66JI/AAAAAAAAVps/JRF98hdA9S8/s640/funny-cat-pictures-016-027.jpg"
+  },
+  {
+    name: "Coco",
+    color: "Red",
+    specialSkill: "Burps minimally.",
+    type: "cat",
+    imageUrl: "http://cathumor.net/wp-content/uploads/2013/12/cat-humor-funny-karate-cat-2.jpg"
+  },
+  {
+    name: "Smokey",
+    color: "Poop-Colored",
+    specialSkill: "Drives at a safe rate of speed in snow or rain.",
+    type: "dino",
+    imageUrl: "https://images.readwrite.com/wp-content/uploads/2018/03/t-rex-dino-quiz-e1490854556549.jpg"
+  },
+  {
+    name: "Muffin",
+    color: "Yellow",
+    specialSkill: "Does not freak out if you haven’t seen his favorite movie (The Big Lebowski).",
+    type: "cat",
+    imageUrl: "http://www.funnycatsite.com/pictures/Close_Up_Yawn.jpg"
+  },
+  {
+    name: "Salem",
+    color: "Poop-Colored",
+    specialSkill: "Proficient in air guitar",
+    type: "dino",
+    imageUrl: "https://www.nation.co.ke/image/view/-/4078922/highRes/1742693/-/maxw/600/-/1453yvh/-/DINO.jpg"
+  },
+  {
+    name: "Callie",
+    color: "Blue",
+    specialSkill: "Listens attentively to boring stories.",
+    type: "dog",
+    imageUrl: "http://cdn.akc.org/content/article-body-image/funny-pembroke_welsh_corgi.jpg"
+  },
+  {
+    name: "Spooky",
+    color: "Black",
+    specialSkill: "Uses litter box at appropriate hours.",
+    type: "cat",
+    imageUrl: "http://www.funnycatsite.com/pictures/Lazy_White_Cat.jpg"
+  },
+  {
+    name: "Miss kitty",
+    color: "Red",
+    specialSkill: "Owns a Nintendo Power Glove.",
+    type: "dino",
+    imageUrl: "https://img.buzzfeed.com/buzzfeed-static/static/2015-11/2/12/enhanced/webdr15/anigif_enhanced-29802-1446485228-10.gif?crop=250:165;0,0&downsize=715"
+  },
+  {
+    name: "Snuggles",
+    color: "Orange",
+    specialSkill: "Is comfortable with jokes about his receding hairline.",
+    type: "cat",
+    imageUrl: "http://funnyanimalphoto.com/wp-content/uploads/2013/08/cat_caught_mouse_thegatewaypundit.jpg"
+  },
+  {
+    name: "Buddy",
+    color: "Red",
+    specialSkill: "Enjoys fine wine.",
+    type: "dog",
+    imageUrl: "http://1.bp.blogspot.com/-VjM0CmtN-vU/T7YX-LXa09I/AAAAAAAADA0/Vt1oGWEG0lw/s1600/sheepdog+border+collie+shakes+off+water+funny+picture+photo+pulling+faces+raspberry+tongue.jpg"
+  },
+  {
+    name: "George",
+    color: "Brown",
+    specialSkill: "Participates in karaoke but does not force others to go out to karaoke.",
+    type: "dog",
+    imageUrl: "http://www.dogbreedplus.com/dog_breeds/images/basset-hound-4.jpg"
+  },
+  {
+    name: "Salem",
+    color: "Red",
+    specialSkill: "Knows the words to 4 rap songs.",
+    type: "cat",
+    imageUrl: "http://funbk.s3.amazonaws.com/wp-content/uploads/2016/06/funny-cat-video-which-will-make-you-laugh-louder.jpg"
+  },
+  {
+    name: "Bubba",
+    color: "Yellow",
+    specialSkill: "Cleans himself.",
+    type: "dog",
+    imageUrl: "https://www.thetrendywhippet.co.uk/wp-content/uploads/2016/11/IMG_1651-600x400.jpg"
+  },
+  {
+    name: "Chloe",
+    color: "Green",
+    specialSkill: "Admits he is wrong",
+    type: "dino",
+    imageUrl: "https://assets.creationmuseum.org/img/pages/1703-DinoDen-TwoCard.jpg"
+  },
+  {
+    name: "Nala",
+    color: "Purple",
+    specialSkill: "Dances when he has to.",
+    type: "cat",
+    imageUrl: "https://tailandfur.com/wp-content/uploads/2016/03/40-Scary-and-Funny-Cat-Pictures-8.jpg"
+  },
+  {
+    name: "Oscar",
+    color: "Green",
+    specialSkill: "Gives hugs with appropriate pressure and for the right length of time.",
+    type: "cat",
+    imageUrl: "http://kittentoob.com/wp-content/uploads/2015/06/funny-cat-with-a-towel.jpg"
+  },
+  {
+    name: "Lucy",
+    color: "Red",
+    specialSkill: "Doesn’t get weirded out by the word “moist.”",
+    type: "dino",
+    imageUrl: "http://lsae2.iypcdn.com/static//modules/uploads/photos/language1/dino-live-22.jpg?119"
+  }
+];
 
-        const printToDom = (divId, textToPrint) => {
-const selectedDiv = document.getElementById(divId);
-selectedDiv.innerHTML = textToPrint;
-        };
+//print function selects element on page and prints parameter string provided to the page.
+const printToDom = (divId, textToPrint) => {
+  const selectedDiv = document.getElementById(divId);
+  selectedDiv.innerHTML = textToPrint;
+};
 
-        const buildDomString = (animalArray) => {
-let domString = '';
-animalArray.forEach((animal) => {
-domString += `<div class='card'>`;
-domString += `<h3>${animal.name} The ${animal.type}</h3>`;
-domString += `<img class='animal-image' src='${animal.imageUrl}' alt='Image of ${animal.name}, the ${animal.color} ${animal.type}'/>`;
-domString += `<p>${animal.name} is a/an ${animal.color} ${animal.type}</p>`;
-domString += `<p>Their special skill is:</p>`;
-domString += `<ul class='unordered-list'>`;
-domString += `<li>${animal.specialSkill}</li>`;
-domString += `</ul>`;
-domString += `</div>`;
-});
-printToDom('animalCardContainer', domString);
-        };
+/*String-builder function loops over the pets array above and pulls bits of information from each animal's object and constructs a string of HTML using the collected information. 
+Function also calls print function above to print the finished string to the page.*/
+const buildDomString = (animalArray) => {
+  let domString = '';
+  animalArray.forEach((animal) => {
+    domString += `<div class='card ${animal.type} padding'>`;
+    domString += `<h3 class='title padding-vertical'>${animal.name} The ${animal.type}</h3>`;
+    domString += `<img class='animal-image padding-vertical' src='${animal.imageUrl}' alt='Image of ${animal.name}, the ${animal.color} ${animal.type}'/>`;
+    domString += `<p class='padding'>${animal.name} is a/an ${animal.color} ${animal.type}</p>`;
+    domString += `<p class='padding'>Their special skill is:</p>`;
+    domString += `<ul class='unordered-list'>`;
+    domString += `<li class='padding'>${animal.specialSkill}</li>`;
+    domString += `</ul>`;
+    domString += `</div>`;
+  });
+  printToDom('animalCardContainer', domString);
+};
 
+/*button click function loops over the array to construct arrays of objects selected by their type key.
+Also uses conditionals to call the string-builder function to feature the array whose type matches the id of the button clicked.
+Also prints all cards to page when all button is pressed.*/
 const buttonClick = (event) => {
-const buttonId = event.target.id;
-console.log(event.target.id);
+  const buttonId = event.target.id;
+  const selectedAnimalArray = [];
+  pets.forEach((animal) => {
+    if (buttonId === animal.type) {
+      selectedAnimalArray.push(animal);
+    }
+  })
+  if (buttonId === 'all') {
+    buildDomString(pets);
+  } else {
+    buildDomString(selectedAnimalArray);
+  }
 };
 
+//attaches event listeners to buttons by their ids, used in tandom with button click function above.
 const eventHandler = () => {
-document.getElementById('cat').addEventListener('click', buttonClick);
-document.getElementById('dog').addEventListener('click', buttonClick);
-document.getElementById('dino').addEventListener('click', buttonClick);
-document.getElementById('all').addEventListener('click', buttonClick);
+  document.getElementById('cat').addEventListener('click', buttonClick);
+  document.getElementById('dog').addEventListener('click', buttonClick);
+  document.getElementById('dino').addEventListener('click', buttonClick);
+  document.getElementById('all').addEventListener('click', buttonClick);
 };
-        
-        const init = () => {
-buildDomString(pets);
-eventHandler();
-        };
-        init();
+
+//Initialize function executes functions to be  run on page load.
+const init = () => {
+  buildDomString(pets);
+  eventHandler();
+};
+init();


### PR DESCRIPTION
Run in browser to display page with light cappuccino brown background and chocolate brown text. On page load, should display a level 1 heading that says something like, "An Introduction To Our Animals", four multi colored buttons, each with a different background, labeled for three types of animals and "all", and multiple rows of cards featuring various animals.

The cards should be color coded by type:

cats: light blue background, bright blue border
dog: light green background, leaf green border
dino: light orange background, burnt orange border
Not sure if my styling took, but will check and complete in next pull request. This stage is mostly for the working cards/buttons.
When you press a button, the corresponding cards for that type of animal should display, filtered to remove other types of animals and their cards. The "all" button reverts the page to display all cards.